### PR TITLE
Included testnet configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,3 +741,32 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   }
   ```
 </details>
+
+<details>
+  <summary>milkomeda</summary>
+  This endpoint is used to get milkomeda info data (minValue & address)
+  Input
+  None (GET request)
+  Output
+  ```js
+  {
+    minimumValue: number,
+    address: string,
+  }
+  ```
+</details>
+<details>
+  <summary>milkomeda/tokens/:network</summary>
+  This endpoint is used to get tokens list per deployment/network
+  Input
+  Name of the network, which list of tokens should be returned (GET request)
+  Output
+  ```js
+  {
+    name: string, // name of the network
+    tokens: [
+      { tokenName: bytesEncodedToHex, policyId: bytesEncodedToHex },
+    ]
+  }
+  ```
+</details>

--- a/config/default.ts
+++ b/config/default.ts
@@ -25,5 +25,17 @@ export default {
     txsHashesRequestLimit: 150,
   },
   blockfrostProjectKey: process.env.BLOCKFROST || "",
-  safeBlockDifference: process.env.SAFE_BLOCK_DIFFERENCE || "10"
+  safeBlockDifference: process.env.SAFE_BLOCK_DIFFERENCE || "10",
+  milkomeda: {
+    minimumValue: 10000000,
+    address: process.env.MILKOMEDA_ADDRESS || "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2",
+    tokensPerNetwork: {
+      internalTestnet: { 
+        tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
+      },
+      publicMainnet: { 
+        tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
+      },
+    }
+  }
 };

--- a/config/default.ts
+++ b/config/default.ts
@@ -1,3 +1,5 @@
+import { NetworkNames } from "@dcspark/milkomeda-constants/types";
+
 export default {
   db: {
     user: process.env.POSTGRES_USER || "",
@@ -30,13 +32,9 @@ export default {
     minimumValue: 10000000,
     address: process.env.MILKOMEDA_ADDRESS || "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2",
     tokensPerNetwork: [{ 
-          name: "testnet",
+          name: NetworkNames.internalTestnet,
           tokens: [ {tokenName: "TADA", policyId: ""} ] 
-        },
-        { 
-          name: "mainnet",
-          tokens: [] 
-        },
+        }
       ]
   }
 };

--- a/config/default.ts
+++ b/config/default.ts
@@ -31,11 +31,11 @@ export default {
     address: process.env.MILKOMEDA_ADDRESS || "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2",
     tokensPerNetwork: [{ 
           name: "testnet",
-          tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
+          tokens: [ {tokenName: "TADA", policyId: ""} ] 
         },
         { 
           name: "mainnet",
-          tokens: [ {name: "ADA", policyId: ""} ] 
+          tokens: [] 
         },
       ]
   }

--- a/config/default.ts
+++ b/config/default.ts
@@ -29,13 +29,14 @@ export default {
   milkomeda: {
     minimumValue: 10000000,
     address: process.env.MILKOMEDA_ADDRESS || "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2",
-    tokensPerNetwork: {
-      internalTestnet: { 
-        tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
-      },
-      publicMainnet: { 
-        tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
-      },
-    }
+    tokensPerNetwork: [{ 
+          name: "testnet",
+          tokens: [ {name: "ADA", policyId: ""}, {name: "TADA", policyId: ""} ] 
+        },
+        { 
+          name: "mainnet",
+          tokens: [ {name: "ADA", policyId: ""} ] 
+        },
+      ]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@dcspark/milkomeda-constants": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dcspark/milkomeda-constants/-/milkomeda-constants-0.2.0.tgz",
+      "integrity": "sha512-IGmaQ2O5KzKIMCsNJnweQ9xIJJLmD0CLSJMlJnQ+yOUTy5oW/MdnUw1ZMPny7HQl3KQJGjtTQYaT7KAIWUDESQ=="
+    },
     "@emurgo/cardano-serialization-lib-nodejs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-4.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,10 +30,18 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@dcspark/cip34-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@dcspark/cip34-js/-/cip34-js-0.1.2.tgz",
+      "integrity": "sha512-9m5h3vXS6C64bUbS5Sv/Mj2G+MyXoEAPlxV+NzvUGeBVmjGlOukmJpLUIK7ym0Bk5q+hTHFoI4j7R/s7SphlBQ=="
+    },
     "@dcspark/milkomeda-constants": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dcspark/milkomeda-constants/-/milkomeda-constants-0.2.0.tgz",
-      "integrity": "sha512-IGmaQ2O5KzKIMCsNJnweQ9xIJJLmD0CLSJMlJnQ+yOUTy5oW/MdnUw1ZMPny7HQl3KQJGjtTQYaT7KAIWUDESQ=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dcspark/milkomeda-constants/-/milkomeda-constants-0.3.0.tgz",
+      "integrity": "sha512-h8HcWG5BZuw+HBwd1NIqYhR7/BeHcatQgN0+I6scXbA7NPoEnsw3YZ615QgAOIZuyCqn8rWNHhoTcwYUFnGJwA==",
+      "requires": {
+        "@dcspark/cip34-js": "^0.1.2"
+      }
     },
     "@emurgo/cardano-serialization-lib-nodejs": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     }
   },
   "dependencies": {
+    "@dcspark/milkomeda-constants": "^0.2.0",
     "@emurgo/cardano-serialization-lib-nodejs": "^4.2.0",
     "axios": "^0.21.4",
     "bech32": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@dcspark/milkomeda-constants": "^0.2.0",
+    "@dcspark/milkomeda-constants": "^0.3.0",
     "@emurgo/cardano-serialization-lib-nodejs": "^4.2.0",
     "axios": "^0.21.4",
     "bech32": "^1.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ import { createTransactionUtilityFunctions } from "./Transactions/userDefinedFun
 import {poolDelegationHistory} from "./services/poolHistory";
 import {handleGetCardanoWalletPools} from "./services/cardanoWallet";
 
-import { getMilkomedaInfo } from "./services/milkomedaInfo";
+import { getMilkomedaInfo, getMilkomedaTokensByNetwork } from "./services/milkomedaInfo";
 
 import { mapTransactionFragsToResponse } from "./utils/mappers";
 
@@ -414,7 +414,12 @@ const routes : Route[] = [
   path: "/milkomeda"
   , method: "get"
   , handler: getMilkomedaInfo()
-}
+},
+{
+  path: "/milkomeda/tokens/:network"
+  , method: "get"
+  , handler: getMilkomedaTokensByNetwork()
+},
 ];
 
 applyRoutes(routes, router);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import { createTransactionUtilityFunctions } from "./Transactions/userDefinedFun
 import {poolDelegationHistory} from "./services/poolHistory";
 import {handleGetCardanoWalletPools} from "./services/cardanoWallet";
 
+import { getMilkomedaInfo } from "./services/milkomedaInfo";
 
 import { mapTransactionFragsToResponse } from "./utils/mappers";
 
@@ -407,6 +408,12 @@ const routes : Route[] = [
   path: "/v0/catalyst/fundInfo"
   , method: "get",
   handler: getFundInfo
+},
+// Milkomeda config info
+{
+  path: "/milkomeda"
+  , method: "get"
+  , handler: getMilkomedaInfo()
 }
 ];
 

--- a/src/services/milkomedaInfo.ts
+++ b/src/services/milkomedaInfo.ts
@@ -1,18 +1,25 @@
 import { Request, Response } from "express";
 import config from "config";
 
+enum NetworkNames { // exemplary names here
+  testnet = "testnet",
+  mainnet = "mainnet",
+}
+
+type NetworkToken = {
+  name: NetworkNames,
+  tokens: Token[]
+}
+
 type Token = {
     name: string
     policyId: string
 }
 
 type MilkomedaConfig = {
-    minimumVal: number,
+    minimumValue: number,
     address: string,
-    tokensPerNetwork: {
-      internalTestnet: Token[],
-      publicMainnet: Token[],
-    }
+    tokensPerNetwork: NetworkToken[]
 };
 
 /**
@@ -21,18 +28,48 @@ type MilkomedaConfig = {
  */
 export const getMilkomedaInfo = () => async (req: Request, res: Response) => {
 
-  let milkomedaInfo!: MilkomedaConfig;
-  try {
-    milkomedaInfo = config.get<MilkomedaConfig>("milkomeda");
-  } catch (error: unknown) {
-    throw new Error(`There was a problem with reading milkomeda config information. ${error}`);
-  }
-
-  if (!milkomedaInfo) {
-    res.status(400).send("MilkomedaInfo is undefined or null");
-    return;
+  const milkomedaInfo = getConfig("milkomeda") as MilkomedaConfig;
+  if (milkomedaInfo instanceof Error) {
+    throw milkomedaInfo;
   } 
-  res.send(milkomedaInfo);
+  res.send({ minimumValue: milkomedaInfo.minimumValue, address: milkomedaInfo.address });
   return;
 
+};
+
+/**
+ * Handler for retrieving Milkomeda tokens for a given network
+ * @returns configuration based on @MilkomedaConfig type. 
+ */
+ export const getMilkomedaTokensByNetwork = () => async (req: Request, res: Response) => {
+  const networks = getConfig("milkomeda.tokensPerNetwork") as NetworkToken[];
+  if (networks instanceof Error) {
+    throw networks;
+  }
+
+  switch (req.params.network) {
+    case NetworkNames.testnet:
+      res.send(getNetworkTokens(networks, NetworkNames.testnet));
+      break;
+    case NetworkNames.mainnet:
+      res.send(getNetworkTokens(networks, NetworkNames.mainnet));
+      break;
+    default:
+      res.status(404).send(`List of tokens for ${req.params.network} was not found`);
+      break;
+  }
+};
+
+const getConfig = (params: string) => {
+  let milkomedaInfo!: MilkomedaConfig | NetworkToken[] | Error;
+  try {
+    milkomedaInfo = config.get(params);
+  } catch (error: unknown) {
+    milkomedaInfo = new Error(`There was a problem with reading milkomeda config information. ${error}`);
+  }
+  return milkomedaInfo;
+};
+
+const getNetworkTokens = (networks: NetworkToken[], networkName: NetworkNames) => {
+    return networks.filter(n => n.name.toString().includes(networkName.toString()))[0]; // one list per deployment so always first element
 };

--- a/src/services/milkomedaInfo.ts
+++ b/src/services/milkomedaInfo.ts
@@ -8,7 +8,7 @@ type NetworkToken = {
 }
 
 type Token = {
-    name: string
+    tokenName: string
     policyId: string
 }
 

--- a/src/services/milkomedaInfo.ts
+++ b/src/services/milkomedaInfo.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from "express";
+import config from "config";
+
+type Token = {
+    name: string
+    policyId: string
+}
+
+type MilkomedaConfig = {
+    minimumVal: number,
+    address: string,
+    tokensPerNetwork: {
+      internalTestnet: Token[],
+      publicMainnet: Token[],
+    }
+};
+
+/**
+ * Handler for retrieving configuration values set inside config file for Milkomeda
+ * @returns configuration based on @MilkomedaConfig type. 
+ */
+export const getMilkomedaInfo = () => async (req: Request, res: Response) => {
+
+  let milkomedaInfo!: MilkomedaConfig;
+  try {
+    milkomedaInfo = config.get<MilkomedaConfig>("milkomeda");
+  } catch (error: unknown) {
+    throw new Error(`There was a problem with reading milkomeda config information. ${error}`);
+  }
+
+  if (!milkomedaInfo) {
+    res.status(400).send("MilkomedaInfo is undefined or null");
+    return;
+  } 
+  res.send(milkomedaInfo);
+  return;
+
+};

--- a/src/services/milkomedaInfo.ts
+++ b/src/services/milkomedaInfo.ts
@@ -1,10 +1,6 @@
 import { Request, Response } from "express";
 import config from "config";
-
-enum NetworkNames { // exemplary names here
-  testnet = "testnet",
-  mainnet = "mainnet",
-}
+import { NetworkNames } from "@dcspark/milkomeda-constants/types";
 
 type NetworkToken = {
   name: NetworkNames,
@@ -18,7 +14,7 @@ type Token = {
 
 type MilkomedaConfig = {
     minimumValue: number,
-    address: string,
+    address: string, // address as string in bech32
     tokensPerNetwork: NetworkToken[]
 };
 
@@ -48,11 +44,8 @@ export const getMilkomedaInfo = () => async (req: Request, res: Response) => {
   }
 
   switch (req.params.network) {
-    case NetworkNames.testnet:
-      res.send(getNetworkTokens(networks, NetworkNames.testnet));
-      break;
-    case NetworkNames.mainnet:
-      res.send(getNetworkTokens(networks, NetworkNames.mainnet));
+    case NetworkNames.internalTestnet:
+      res.send(getNetworkTokens(networks, NetworkNames.internalTestnet));
       break;
     default:
       res.status(404).send(`List of tokens for ${req.params.network} was not found`);

--- a/tests/milkomedaInfo.test.ts
+++ b/tests/milkomedaInfo.test.ts
@@ -1,0 +1,28 @@
+import axios from "axios";
+import { expect } from "chai";
+import { config, } from "./config";
+
+const endpoint = config.apiUrl;
+const testableUri = endpoint + "milkomeda";
+
+const minValueToCheck = 10000000;
+const milkomedaAddressToCheck = "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2";
+
+describe("/milkomeda", function() {
+  it("should return list of all Milkomeda parameters", async() => {
+    const result = await axios({method: "get", url: testableUri});
+
+    expect(result.status).to.be.equal(200);
+    expect(result.data).to.be.not.null;
+  });
+  it("should verify the payload", async() => {
+    const result = await axios({method: "get", url: testableUri});
+
+    expect(result.data.minimumValue).to.be.equal(minValueToCheck);
+    expect(result.data.address).to.be.equal(milkomedaAddressToCheck);
+    expect(result.data.tokensPerNetwork).to.be.ownProperty("internalTestnet");
+    expect(result.data.tokensPerNetwork).to.be.ownProperty("publicMainnet");
+    expect(result.data.tokensPerNetwork.internalTestnet.tokens).to.be.instanceOf(Array);
+    expect(result.data.tokensPerNetwork.publicMainnet.tokens).to.be.instanceOf(Array);
+  });
+});

--- a/tests/milkomedaInfo.test.ts
+++ b/tests/milkomedaInfo.test.ts
@@ -1,13 +1,14 @@
 import axios from "axios";
 import { expect } from "chai";
 import { config, } from "./config";
+import { NetworkNames } from "@dcspark/milkomeda-constants/types";
 
 const endpoint = config.apiUrl;
 
 const minValueToCheck = 10000000;
 const milkomedaAddressToCheck = "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2";
 
-describe.only("/milkomeda", function() {
+describe.only("/milkomeda endpoints check", function() {
   it("should return list of all Milkomeda parameters", async() => {
     const result = await axios({method: "get", url: endpoint + "milkomeda"});
     expect(result.status).to.be.equal(200);
@@ -19,7 +20,7 @@ describe.only("/milkomeda", function() {
     expect(result.data.address).to.be.equal(milkomedaAddressToCheck);
   });
   it("should verify payload of specific tokens for given network", async() => {
-    const result = await axios({method: "get", url: endpoint + "milkomeda/tokens/testnet"});
+    const result = await axios({method: "get", url: `${endpoint}milkomeda/tokens/${NetworkNames.internalTestnet}`});
     expect(result.data.tokens).to.be.instanceOf(Array);
     expect(result.data.tokens[0].tokenName).to.be.equal("TADA");
   });

--- a/tests/milkomedaInfo.test.ts
+++ b/tests/milkomedaInfo.test.ts
@@ -3,26 +3,24 @@ import { expect } from "chai";
 import { config, } from "./config";
 
 const endpoint = config.apiUrl;
-const testableUri = endpoint + "milkomeda";
 
 const minValueToCheck = 10000000;
 const milkomedaAddressToCheck = "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2";
 
 describe("/milkomeda", function() {
   it("should return list of all Milkomeda parameters", async() => {
-    const result = await axios({method: "get", url: testableUri});
-
+    const result = await axios({method: "get", url: endpoint + "milkomeda"});
     expect(result.status).to.be.equal(200);
     expect(result.data).to.be.not.null;
   });
-  it("should verify the payload", async() => {
-    const result = await axios({method: "get", url: testableUri});
-
+  it("should verify Milkomeda parameters (no token list here)", async() => {
+    const result = await axios({method: "get", url: endpoint + "milkomeda"});
     expect(result.data.minimumValue).to.be.equal(minValueToCheck);
     expect(result.data.address).to.be.equal(milkomedaAddressToCheck);
-    expect(result.data.tokensPerNetwork).to.be.ownProperty("internalTestnet");
-    expect(result.data.tokensPerNetwork).to.be.ownProperty("publicMainnet");
-    expect(result.data.tokensPerNetwork.internalTestnet.tokens).to.be.instanceOf(Array);
-    expect(result.data.tokensPerNetwork.publicMainnet.tokens).to.be.instanceOf(Array);
+  });
+  it("should verify payload of specific tokens for given network", async() => {
+    const result = await axios({method: "get", url: endpoint + "milkomeda/tokens/testnet"});
+    expect(result.data.tokens).to.be.instanceOf(Array);
+    expect(result.data.tokens[0].name).to.be.equal("ADA");
   });
 });

--- a/tests/milkomedaInfo.test.ts
+++ b/tests/milkomedaInfo.test.ts
@@ -7,7 +7,7 @@ const endpoint = config.apiUrl;
 const minValueToCheck = 10000000;
 const milkomedaAddressToCheck = "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2";
 
-describe("/milkomeda", function() {
+describe.only("/milkomeda", function() {
   it("should return list of all Milkomeda parameters", async() => {
     const result = await axios({method: "get", url: endpoint + "milkomeda"});
     expect(result.status).to.be.equal(200);
@@ -21,6 +21,6 @@ describe("/milkomeda", function() {
   it("should verify payload of specific tokens for given network", async() => {
     const result = await axios({method: "get", url: endpoint + "milkomeda/tokens/testnet"});
     expect(result.data.tokens).to.be.instanceOf(Array);
-    expect(result.data.tokens[0].name).to.be.equal("ADA");
+    expect(result.data.tokens[0].tokenName).to.be.equal("TADA");
   });
 });

--- a/tests/milkomedaInfo.test.ts
+++ b/tests/milkomedaInfo.test.ts
@@ -8,7 +8,7 @@ const endpoint = config.apiUrl;
 const minValueToCheck = 10000000;
 const milkomedaAddressToCheck = "addr_test1qq6gwl46frfwfk593pqjg39vym476s64n9cmykdl7lv7w32jdqlum6v4sc3l3w9nmuf3ean86n2y7pl83tpxl2qjdw8qmjljz2";
 
-describe.only("/milkomeda endpoints check", function() {
+describe("/milkomeda endpoints check", function() {
   it("should return list of all Milkomeda parameters", async() => {
     const result = await axios({method: "get", url: endpoint + "milkomeda"});
     expect(result.status).to.be.equal(200);


### PR DESCRIPTION
The following PR extends `cardano-backend` with test configurations for Milkomeda.

There are 2 new endpoints added. 

1. `/milkomeda` is a `GET` request. Returns: 
- Milkomeda minimum value
- Milkomeda address

Resulting payload:
```bash
{
    "minimumValue": minimumAmountOfLovelaces,
    "address": "milkomedaAddress"
}
```

2.`milkomeda/tokens/:network` is a `GET` request. Returns: 
- List of tokens per deployment/network
Resulting payload:
```bash
{
    "name": "networkName",
    "tokens": [
        {
            "name": "tokenName1",
            "policyId": hexString
        },
        {
            "name": "tokenName2",
            "policyId": hexString
        }
    ]
}
```
