### PR TITLE
in accoutState query aggregate only by addr hash

### DIFF
--- a/src/services/accountState.ts
+++ b/src/services/accountState.ts
@@ -42,7 +42,7 @@ const accountRewardsQuery = `
       addr_id
   ) as "totalReward" on queried_addresses.id = "totalReward".addr_id
 
-  group by queried_addresses.id, queried_addresses.hash_raw`;
+  group by queried_addresses.hash_raw`;
 
 interface RewardInfo {
   remainingAmount: string;


### PR DESCRIPTION
Sorry for reopening this, but I was going to ask the emurgo guys for their opinion on aggregating by "hash_raw" in the accountState querry and then I realised that the old way of aggregating by "id" didn't even make sense. If we're summing rewards for an address then we should just aggregate by the address and not by the table id.