### PR TITLE
Fix multipolicy 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "stop": "pm2 stop pm2.yaml",
     "dev": "tsc-watch --onSuccess \"node ./dist/index.js\"",
     "eslint": "eslint src tests",
-    "test": "mocha -r ts-node/register tests/**/*.test.ts --slow 0",
+    "test": "mocha -r ts-node/register tests/tokenMetadata.test.ts --slow 0",
     "testtxhist": "mocha -r ts-node/register tests/txHistory.test.ts",
     "typecheck": "tsc --project tsconfig.typecheck.json"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "stop": "pm2 stop pm2.yaml",
     "dev": "tsc-watch --onSuccess \"node ./dist/index.js\"",
     "eslint": "eslint src tests",
-    "test": "mocha -r ts-node/register tests/tokenMetadata.test.ts --slow 0",
+    "test": "mocha -r ts-node/register tests/**/*.test.ts --slow 0",
     "testtxhist": "mocha -r ts-node/register tests/txHistory.test.ts",
     "typecheck": "tsc --project tsconfig.typecheck.json"
   },

--- a/src/utils/tokenMetadata.ts
+++ b/src/utils/tokenMetadata.ts
@@ -32,7 +32,7 @@ function createGetMultiAssetTxMintMetadataQuery(assets: PolicyIdAssetMapType) {
   // so we need to give each one of these an argument number in postgres
   // note: postgres has a max of 65535 (so 32K pairs)
   // but it's unlikely somebody passes 32K pairs in a single request to the backend
-  let index = 1;
+  let index = 1; // recall: SQL arguments start at 1 (not 0)
   const whereConditions = Object.keys(assets)
     .map((policyIdHex: string) => {
       const assetNames = assets?.[policyIdHex] ?? [];

--- a/tests/tokenMetadata.test.ts
+++ b/tests/tokenMetadata.test.ts
@@ -9,25 +9,44 @@ const testableUri = endpoint + "multiAsset/metadata";
 describe("/multiAsset/metadata", function() {
   this.timeout(10000);
   it("returns", async() => {
-      const spaceBudzPolicyId = "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc";
-      const SpaceBud2589 = "537061636542756432353839"; // note: hexencoding
+    const spaceBudzNft = {
+        policyId: "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc",
+        // hex encoding (SpaceBud2589)
+        assetName: "537061636542756432353839",
+        result: {
+            name: "SpaceBud #2589",
+            imageUrl: "ipfs://QmTHaFdaj8hSjf3Xo9gFGxEvpgLX6CHCddbaGbzK4WbYz6",
+            policy: "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc"
+        }
+    };
+
+    const charlesNft = {
+        policyId: "2a9f36ce07c7264420f46841a4019fa2c4b2ee3c0e3d50e48e5feea5",
+        // hex encoding (CharlesHoskinson1211of100)
+        assetName: "436861726c6573486f736b696e736f6e313231316f66313030",
+        result: {
+            "name": "Charles Hoskinson12-11of100",
+            "imageUrl": "ipfs://Qmb3SmS88WHCBZ1NDz5yGGgPzGBJqUkyB5DqwNCF6WjX6W",
+            "policy": "2a9f36ce07c7264420f46841a4019fa2c4b2ee3c0e3d50e48e5feea5"
+        }
+    };
     const result = await axios({
         method: "post",
         url: testableUri,
         data: {
             policyIdAssetMap: {
-                [spaceBudzPolicyId]: [SpaceBud2589]
+                [spaceBudzNft.policyId]: [spaceBudzNft.assetName],
+                [charlesNft.policyId]: [charlesNft.assetName]
             }
         }
     });
     
     expect(result.data).to.have.property("data");
-    expect(result.data.data).to.have.property(spaceBudzPolicyId);
-    expect(result.data.data[spaceBudzPolicyId]).to.have.property(SpaceBud2589);
-    expect(result.data.data[spaceBudzPolicyId][SpaceBud2589]).to.be.eql({
-        name: "SpaceBud #2589",
-        imageUrl: "ipfs://QmTHaFdaj8hSjf3Xo9gFGxEvpgLX6CHCddbaGbzK4WbYz6",
-        policy: "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc"
-    });
+
+    for (const nft of [spaceBudzNft, charlesNft]) {
+        expect(result.data.data).to.have.property(nft.policyId);
+        expect(result.data.data[nft.policyId]).to.have.property(nft.assetName);
+        expect(result.data.data[nft.policyId][nft.assetName]).to.be.eql(nft.result);
+    }
   });
 });


### PR DESCRIPTION
The `multiAsset/metadata` query currently fails if you pass multiple policies to it. This is because the SQL parameter index was being reset for every policy in the loop

# Before fix

```
(encode(ma.name, 'hex') = ($1)::varchar and encode(ma.policy, 'hex') = ($2)::varchar )
or
(encode(ma.name, 'hex') = ($1)::varchar and encode(ma.policy, 'hex') = ($2)::varchar )
```

# After fix

```
(encode(ma.name, 'hex') = ($1)::varchar and encode(ma.policy, 'hex') = ($2)::varchar )
or
(encode(ma.name, 'hex') = ($3)::varchar and encode(ma.policy, 'hex') = ($4)::varchar )
```