### PR TITLE
fix: allow all success codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-cardano-backend",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Wrapped for cardano-db-sync and cardano-graphql with endpoints useful for light wallets",
   "main": "src/index.ts",
   "scripts": {

--- a/src/services/signedTransaction.ts
+++ b/src/services/signedTransaction.ts
@@ -14,6 +14,9 @@ const contentTypeHeaders = {
   project_id: blockfrostProjectKey,
 };
 
+const isSuccessCode = (statusCode: number): boolean => {
+  return statusCode >= 200 && statusCode <= 299;
+};
 const submitToQueue = async (req: Request, res: Response) => {
   try {
     const buffer = Buffer.from(req.body.signedTx, "base64");
@@ -56,7 +59,7 @@ const submit = async (req: Request, res: Response) => {
       headers,
     });
 
-    if (endpointResponse.status === 200) {
+    if (isSuccessCode(endpointResponse.status)) {
       res.send([]);
       return;
     } else {


### PR DESCRIPTION
https://app.shortcut.com/dcspark/story/2531/allow-any-success-response-in-backend-sendtx-endpoint