### PR TITLE
Extending limit for request size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-cardano-backend",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Wrapped for cardano-db-sync and cardano-graphql with endpoints useful for light wallets",
   "main": "src/index.ts",
   "scripts": {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -12,7 +12,7 @@ export const handleCors = (router: Router): Router =>
 
 export const handleBodyRequestParsing = (router: Router): void => {
   router.use(parser.urlencoded({ extended: true }));
-  router.use(parser.json());
+  router.use(parser.json({ limit: "10mb" }));
 };
 
 export const handleCompression = (router: Router): void => {


### PR DESCRIPTION
Very big request results in error:
`{"error":{"response":"request entity too large"}}`
Therefore it has to be extended. 
I propose form default 1MB to 10MB

Please note that sub-service (token-registry-service) has to be adjusted as well. When sub-service is NOT adapted it will result in error 500 and cardano-back stuck.

Merge with:
https://github.com/dcSpark/token-registry-service/pull/7